### PR TITLE
Updated Mobile Tips

### DIFF
--- a/contribution/mobile/tips.txt
+++ b/contribution/mobile/tips.txt
@@ -2,23 +2,10 @@
 // one line one tip :)
 
 // Uncategoried
-Scrap your items to get Tech Scraps; reverse engineer them to gain PRINTING experience.
 You can sell your items in the [PLAYER MARKET].
-Your crafting ranks cannot exceed your overall LEVEL; don't waste time doing research when you're capped.
-HP regenerates 100% after each battle unless you're in a dungeon!
-You always attack first; use it to your advantage!
-You can repair your damaged equipped gear at the [WEAPON SMITH].
 Your inventory has a storage limit; keep an eye on it or you will lose loot.
-Shields regenerate after you defeat an enemy in a dungeon.
-You can do reverse engineering at the [JOB HUB].
-"Trash" quality equipment is still useful for getting Tech Scraps and gaining PRINTING experience.
-No friends online to help with that dungeon quest? Try sharing your dungeon in the chat!
-Craft Pain Away to recover health between fights in dungeons.
-Dungeons are a great source for AI Cores and Hash Processors.
+Dungeons are a great source of AI Cores and Hash Processors.
 SCAVENGE to find components for crafting ammo and medicine.
-Printing always results in items the same level as your PRINTING RANK.
-Beware of enemies described as tough, angry, or shielded.
-There's a tutorial under the 'Profile' tab. Use it often!
 Unequip upgrade modules when switching equipped gear to make them available for the new gear.
 Gear and upgrades "of expansion" increase your inventory size!
 Healing items such as Pain Away Spray heal your teammates as well!
@@ -26,32 +13,18 @@ BTC (bitcoin) in this game isn't redeemable; it's just in-game currency. :'(
 Don't forget to send a thank you to @DexterHuang in chat for making this game!
 You can store excess upgrade modules in High-Quality equipment to save inventory space.
 Dying a lot? Level up your PRINTING RANK to your player level, then print new equipment!
-Feeling faint? Take a break and get some food.
-Confused about the cache that just fell into your hand? Go to the [MOLECULAR 3D PRINTER] and make some gear.
-Equipment cache comes in 6 rarities: Trash, Common, High Quality, Rare, Legendary, and Epic.
+Confused about the equipment cache you just found? Go to the [MOLECULAR 3D PRINTER] and make some gear.
+Equipment caches come in 6 rarities: Trash, Common, High Quality, Rare, Legendary, and Epic.
 Did you know you can access the mobile version of the game from your computer? Go to cybercodeonline.com and shrink the browser window!
-Like the game? Be sure to leave a review on the iOS app store or the Google Play store!
-Studies show that mobs with the "Agile" tag grant more EXP.
-Not leveling as fast as you like? Try dungeon diving! (You get 2x more exp)
 Always carry medical parts and ammo parts on you while in a dungeon.
-Look at this tips bar. We have some awesome tips for you.
 Epic caches are extremely rare. Consider yourself lucky if you get one.
 Low on BTC? Get some by cryptomining with Hash Processors at the [JOB HUB], or sell Hash Processors on the [MARKET].
-Challenge dungeons always have a tough boss, so don't forget to take your friends with you when venturing into one of them.
-You can exchange Units you buy with rare global buffs such as AFK time accelerators, EXP, and BTC bonuses.
 Higher SCAVENGE skill allows you to scavenge in higher level areas and get more loot.
-The gear you get from the [MOLECULAR 3D PRINTER] is always based on your PRINTING RANK and not on your overall LEVEL, so always keep your PRINTING RANK up to date.
-Enemies with descriptions (i.e. Shielded / Mad / Angry) are tougher, but give better rewards!
-Donations and membership do not grant any in-game advantage.
 Have you looked at your inventory or thought to do any crafting yet? Because you should!
-When you die, you'll lose some of your EXP and 10% of your BTC, so be careful!
-Use primary weapons to overpower the street monsters and save ammo.
 Secret Key Fragments appear in both normal and challenge dungeons, while Experience Memories only appear in challenge dungeons.
 If you are reading this while driving, PUT THE PHONE DOWN!
 Don't chat and drive!
 While Antimatter Charges aren't exactly rare, they aren't easy to come by either. One shouldn't use them in every single encounter.
-You can't enter a dungeon that is more than 10 levels above your level. It's for your own good.
-Fight above your level for juicy EXP.
 Game broken? Refresh or restart app.
 AFK never ending? Refresh or restart app.
 Tried refreshing or restarting the app?
@@ -59,68 +32,52 @@ Always check the market prices before putting something up for sale!
 You need a lot of Tech Scraps to open a locked container.
 Scrap your unused items to get Tech Scraps; you will need them to open locked containers.
 Ask your friendly neighbor for prices of assorted items!
-It's recommended to redeem dungeon quest rewards and memory experiences with the 180% xp buff. You'll gain almost double EXP!
 After early game, Pain Aways become virtually useless, so feel free to recycle them for ~50% chance of a Medical Tech Part per Pain Away.
-Are you at Death's door in the middle of the treasure room? Ask for support in the chat and direct them to your dungeon.
-An unprepared dungeon explorer is a dead dungeon explorer.
-If you can't afford to print a rare item cache, try checking out the [PLAYER MARKET] first and seek cheaper alternatives. You might find affordable items for your level.
+If you can't afford to print a rare equipment cache, try checking out the [PLAYER MARKET] first and seek cheaper alternatives. You might find affordable items for your level.
 Inventory management is crucial.
 You can switch equipment during a dungeon.
 You can craft healing items mid-dungeon to restock.
-You can add friends in this game. Just click on their username and scroll down to 'add friend'.
 Each mod can add up to 5% critical chance bonus.
 You can obtain a steady source of Ai Cores and Hash Processors by defeating the boss in a challenge difficulty dungeon.
 Need some extra space in your inventory? Equip gear or modules with the "pocket" modifier.
-Begging for Global Time Skips is generally frowned upon by the community, so please don't do it.
-If your game is frozen or you can't move in a dungeon try closing and reopening the game.
-Complete quests for a good amount of BTC, EXP, and even items!
-Consider yourself lucky if you get an Epic Cache.
 Crit damage on upgrades can go above 10%!
 Remember to max out your PRINTING RANK before printing your equipment.
-Did you find a closed container? You can open it in [TERMINAL], but you'll need some Tech Scrap and BTC.
-If you feel your inventory is constantly full, now might be a good idea to consider that new backpack upgrade.
-Want to be in a gang? You will have to be invited by someone. There is no application button.
-Are your healing items healing for half of your max HP or less? Consider transitioning to the next tier of healing items.
-While challenge dungeons take longer than normal ones and are harder, the boss in challenge dungeons gives a ludicrous amount of experience and loot.  
-Since you can't send BTC to players directly, AI Cores or other items can replace BTC in direct trades with the gift function. Stock up when buying items from a trader directly.
-In public dungeons, all loot is available to players inside. No need to worry about stealing loot!
-Look out for special events like AFK global time skips or cailbration boosts in Chat every now and then. You don't want to miss out on these!
+Did you find a locked container? You can open it in [TERMINAL], but you'll need some Tech Scrap and BTC.
+If you feel your inventory is constantly full, now might be a good time to consider that new backpack upgrade.
 Want to be more efficient at dungeons after doing them for quite some time? Take a break.
 You can machine craft more Tech Scraps at the [GANG] via Automatic Recycler.
-If you need BTC, try selling unwanted items to the Weaponsmith.  The "Bargaining" stat helps with this.
-Inventory getting full?  Lost BTC when you flatlined?  Store items or BTC in the [BANK OF ARASAKA].
-If you are annoyed by kill-stealing, it's time to try adding password to dungeons.
+If you need BTC, try selling unwanted items to the Weaponsmith. The "Bargaining" stat helps with this.
+Inventory getting full? Lost BTC when you flatlined? Store items or BTC in the [BANK OF ARASAKA].
 
 // Experience, Leveling
 Scrap your items to get Tech Scraps, then reverse engineer them to gain printing exp.
 Your crafting ranks cannot exceed your level; don't waste time doing crafting research when you're capped.
 You can reverse engineer scraps at [JOB HUB] to gain printing exp.
-"Trash" quality equipments are useful for getting tech scraps and printing exp.
+"Trash" quality equipment is useful for getting tech scraps and printing exp.
 Level up a skill at the [COMMERCIAL AREA] when you have time to spare.
-Study shows that mobs with the "Agile" tag grants more exp.
+Studies show that mobs with the "Agile" tag grant more exp.
 Not leveling as fast as you'd like? Try dungeon diving! (You get 2x more exp)
-The gear you get from the [MOLECULAR PRINTER] is always based on your Printing level and not on your overall one, so make sure you always keep your printing level up.
+The gear you get from the [MOLECULAR PRINTER] is always based on your Printing level (not your player level), so make sure you always keep your printing level up.
 To keep the game fresh, it's impossible to gain EXP and loot from low level enemies or dungeons after a certain level.
 Fight enemies and dungeons above your level for more juicy exp.
-Wait until someone uses the 180% exp buff to redeem dungeon quest rewards and memory experiences to gain greater experience.
+Wait until someone uses the 180% exp buff to redeem dungeon quest rewards to gain greater experience.
 Doing challenge dungeons with other players is the fastest way to gain levels while having fun!
-Complete quests for a good amount of Bitcoin and exp.
+Complete quests for a good amount of BTC, EXP, and even items!
 How to level up faster? Stay away from chat.
 In order to craft a key to unlock the next area, you need to travel to all 3 sub-areas and get the key in each dungeon boss room.
 Is an area locked even though you unlocked it with a key? You may be underleveled.
-SCAVANGING or doing afk tasks at [COMMERCIAL AREA] has little impact to spaces in your inventory.
-When your level is high, you might notice quests are no longer impactful to your BTC balance. You can still do them for fun.
-Printing high quality caches is significantly more expensive than common and trash caches.
+SCAVENGING or doing afk tasks at [COMMERCIAL AREA] has little impact on your inventory space.
+When your level is high, you might notice that quests are no longer impactful to your BTC balance. You can still do them for fun.
+Printing high quality caches is significantly more expensive than printing common and trash caches.
 
 // Social, Chat, UI, Systems
-In the chat terminal, you can press [Up Arrow] key to access the last message you send.
 No friends online to help with that dungeon quest? Try posting your Dungeon ID in the chat!
 In the chat terminal, type @ to mention another player.
 Don't forget to send a thank you to @DexterHuang in chat for making this game.
 There's a tutorial under the 'Profile' tab.
 You can access the mobile version of the game from your computer by going to cybercodeonline.com and shrinking the browser window!
 We also have a desktop version of this game at cybercodeonline.com!
-You can add friends in this game. Just click on their username and scroll down to Add to Friend List.
+You can add friends in this game. Just tap on their username and scroll down to "Add to Friend List".
 Begging for Global Time Skips is generally frowned upon by the community.
 If your game is frozen or you can't move in a dungeon, try closing and reopening the game.
 Game broken? Refresh or reload.
@@ -130,14 +87,14 @@ Feel free to share unwanted gear.
 Be nice to other players. :)
 Inventory full? Sell your non-essential items in the player market or to your local trader in chat!
 Being in a gang has the perks of accessing a few new AFK tasks, as well as the gang dungeon. Plus, playing with others just makes the game much better!
-Want to be in a gang? You will have to be invited by someone. There is no application button. 
+Want to be in a gang? You will have to be invited by someone. There is no application button.
 If you have a dungeon that you would like to leave, it is good etiquette to post an invite to chat before leaving, so that everyone can hop on by and loot the dungeon.
-Epic caches cost an arm and a leg. If you are at a low level, try selling them thru auction in chat to boost your balance by a significant amount!
+Epic caches cost an arm and a leg. If you are at a low level, try selling them though an auction in chat to boost your balance by a significant amount!
 Since you can't send BTC to players directly, AI Cores and other items replace BTC in direct trades with the gift function. Stock up when buying items from a trader directly.
 Look out for special events like AFK global time skips or calibration boosts in Chat every now and then. You don't want to miss out on these!
 Check the player market often to get an idea on the value of your inventory, and if you should buy or sell your items!
 Gear that has a 100% or more chance to break in calibration needs the percentage lowered by using a buff in the Arasaka Unit Exchange. This benefits not only you, but everyone else playing.
-Calibrating gear makes it stronger, but calibrated gear cannot be gifted or sold.
+Calibrating gear makes it stronger, but calibrated gear cannot be gifted or sold until you use a [Factory Reset Shard] on it.
 Each level of calibration on gear adds more to the item than the last level, but is more likely to break the item as well.
 You can use AI cores in locations with much higher level than you. Collect keys from dungeons to unlock them early.
 
@@ -150,42 +107,39 @@ An equipement with higher quality does not mean its attribute is better, but its
 BARGAIN equipment are not worth more when sold, instead, when you wear BARGAIN equipment, anything you sell to NPC will worth more.
 
 // Combat, Enemies, Allies
-HP goes back to full after each battle, unless you're in a dungeon!
-You will always recover to full health while not in a dungeon.
+Your health goes back to full after each battle, unless you're in a dungeon!
 You always attack first, so make good use of that advantage!
-Shields regenerate after you defeat an enemy in the dungeon.
+Shields regenerate after you defeat an enemy in a dungeon.
 Craft Pain Away to be able to recover health between fights in dungeons.
 Beware of enemies with extra descriptors such as tough, angry or shielded.
 Enemies with descriptors (e.g., Shielded / Mad / Angry) are tougher, but they give better rewards!
 Secret keys are needed to access higher level stations; search dungeons for their fragments!
 Remember the CCO mantra: Hit, Heal, Hit.
-Challenge dungeons always have a tough boss so don't forget to bring your friends with you when venturing in.
-When you die, you'll lose some of your experience and 10% of your Bitcoins, so be careful!
-Use only primary weapons to overpower street monsters to save ammo.
-You can't enter a dungeon that is 10 levels above your level. It's for your own good.
+Challenge dungeons always have a tough boss, so don't forget to take your friends with you when venturing into one of them.
+When you die, you'll lose some of your experience and 10% of your held BTC, so be careful!
+Use primary weapons to overpower street monsters and save ammo.
+You can't enter a dungeon that is 10+ levels above your level. It's for your own good.
 If you can survive one hit in a dungeon with a sizable health bar remaining, you can win by keeping yourself healed!
 Are you at Death's door in the middle of the treasure room? Ask for support in the chat and direct them to your dungeon!
 Are enemies taking too long to kill? Try increasing your critical chance and critical damage modifier.
 You can enter dungeons already in progress to get quests and loot!
 Consider swapping to better healing items when the current ones you're using heal less than 50% of your health.
 Don't forget to craft healing items before diving into dungeon!
-Are you healing items healing for half of your max HP or less? Consider transitioning to the next tier of healing items.
 Tough enemies deal more damage than normal enemies, so have your healing items at the ready.
 There's a maximum of 4 enemies in a non-boss dungeon room.
-While challenge dungeons are harder than normal ones, the boss in challenge dungeons gives a ludicrous amount of experience and loot.
+While challenge dungeons are harder than normal ones, the boss in challenge dungeons give a ludicrous amount of experience and loot.
 Want to make sure everyone gets loot in a public dungeon? Make sure everyone deals at least 20% of the mob's max HP as damage.
-In public dungeons, everyone can get the loot. No need to worry about stealing loot!
-If you are annoyed by kill stealing (which rips experience), it's time to add dungeon passwords.
-Angry and Mad enemies are quicker to kill than tough, marksman, agile or shielded enemies.
+In public dungeons, everyone can get the loot. No need to worry about any of it being stolen!
+If you are annoyed by kill-stealing, it's time to try adding a password to your dungeons.
+Angry and Mad enemies are quicker to kill than Tough, Marksman, Agile or Shielded enemies.
 You can join a dungeon without fighting anything. Use it to your advantage, including completing quests or taking keys.
 DO NOT press your luck if you feel your health is just enough to take another hit.
 If you pressed attack and the game lags, DO NOT SPAM ATTACK! Wait, refresh or restart the game.
 If you apparently clicked on an enemy but it shows "Nothing is found", DON'T CLICK "Go back", you should refresh the game.
 
 // Misc, Fun, Purchases
-Feeling faint? Stop playing and get some food.
+Feeling faint? Take a break and get some food.
 Don't forget to hydrate yourself!
-All the fancy coding making you dizzy? Try the mobile version of CCO.
 Go ahead. Hand over that potato to our awesome dev Dexter Huang.
 Look at this tips bar down here. We have some awesome tips for you.
 It's customary to go clockwise in public dungeons.
@@ -195,8 +149,8 @@ Don't forget to feed your pets!
 Please don't drive and play; the game can wait.
 Not reading the tutorial will make one feel lost & confused.
 Like the game? Be sure to leave a review on the iOS store or the Google Play store!
-You can exchange Units you buy with rare global buffs such as AFK time reduction and EXP and Bitcoin bonuses.
-An unprepared dungeon explorer is a dead explorer.
+You can exchange Units you buy with rare global buffs such as AFK time accelerators, EXP, and BTC bonuses.
+An unprepared dungeon explorer is a dead dungeon explorer.
 Make sure to breathe while playing.
 When you feel dizzy, stop playing and GO TO SLEEP!
 Dying is bad for your health. (citation needed)
@@ -208,4 +162,3 @@ If you like CyberCodeOnline, consider suggesting new ideas, dungeon rooms, tips,
 There is no pay to win aspect in CyberCodeOnline. Items bought through the Arasaka Unit Exchange benefit everyone, and the Cosmetic Cyberwear is purely cosmetic.
 Want to stop making the same mistakes as a beginner? Play more.
 Want to be more efficient at doing dungeons after doing it for quite some time? Stop doing them and get some rest.
-Looking for the tutorial?  It's in Profile -> Tutorial.


### PR DESCRIPTION
-Various minor fixes such as spelling, grammar, and clarity improvements
-Removed many, _many_ duplicate tips
-Removed the obsolete tip about repairing equipment
-Removed the reference to "Experience Shards", as those are no longer in the game
-Removed the tip about pressing the "Up Arrow" in chat; these tips are for the mobile version, silly!
-Removed the tip that says "Try the mobile version of CCO"... lol